### PR TITLE
Bump buildtool and fix flaws in build.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         echo "$ANDROID_HOME/build-tools/29.0.2" >> $GITHUB_PATH
         mkdir -p ~/bin
-        wget https://github.com/Aliucord/buildtool/releases/download/v0.0.3/buildtool -P ~/bin
+        wget https://github.com/Aliucord/buildtool/releases/download/v0.1.0/buildtool -P ~/bin
         chmod +x ~/bin/buildtool
         chmod +x $GITHUB_WORKSPACE/src/gradlew
         echo "{\"aliucord\":\"$GITHUB_WORKSPACE/Aliucord\",\"plugins\":\"$GITHUB_WORKSPACE/src\",\"androidSDK\":\"$ANDROID_HOME\",\"outputsPlugins\":\"$GITHUB_WORKSPACE/builds\"}" > ~/config.json

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,10 @@
-#/bin/sh
+#!/bin/sh
 # POSIX Shell script to build plugin, push it to device, and reopen discord via adb.
-set -e
-old_dir=$PWD
+trap "cd '$PWD'" EXIT
+set -ex
 cd ../buildtool
-./main -p $1
+./main -p "$1"
 cd ./buildsPlugins
-adb push ./${1}.apk /storage/emulated/0/Aliucord/plugins
+adb push "./${1}.apk" /storage/emulated/0/Aliucord/plugins
 adb shell am force-stop com.aliucord
 adb shell monkey -p com.aliucord -c android.intent.category.LAUNCHER 1
-cd $old_dir


### PR DESCRIPTION
uses trap to cd back to be more reliable in case of errors and quotes args so it doesnt break if ur plugin/PWD has spaces or other weird characters in it

thanks for this template btw 