### PR TITLE
improve build.yml slightly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,16 @@
 name: Build
 
+# https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency
+concurrency: 
+  group: "build"
+  cancel-in-progress: true
+
 on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '*.md'
 
 jobs:
   build:


### PR DESCRIPTION
- added a [concurrency](https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/) settings, which makes sure only the latest commits gets built if multiple builds would be running normally.

- made changes to md files (like readme.md) not trigger the workflow