### PR TITLE
feat(ci): update build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,8 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'gradle.properties'
-      - 'gradle/**'
-      - 'plugin/**'
-      - '**.gradle.kts'
-      - '.github/**'
+    paths-ignore:
+      - '*.md'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,12 @@ jobs:
           ref: "builds"
           path: "builds"
 
+      - name: Checkout Aliucord
+        uses: actions/checkout@master
+        with:
+          repository: "Aliucord/Aliucord"
+          path: "repo"
+
       - name: Setup JDK 11
         uses: actions/setup-java@v4
         with:
@@ -44,6 +50,7 @@ jobs:
       - name: Build plugins
         run: |
           cd $GITHUB_WORKSPACE/src
+          chmod +x gradlew
           ./gradlew make generateUpdaterJson
           cp plugin/**/build/*.zip $GITHUB_WORKSPACE/builds
           cp build/updater.json $GITHUB_WORKSPACE/builds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,52 +1,45 @@
-name: Build
-
-# https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency
-concurrency: 
-  group: "build"
-  cancel-in-progress: true
+name: "Build"
 
 on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '*.md'
+    paths:
+      - 'gradle.properties'
+      - 'gradle/**'
+      - 'plugin/**'
+      - '**.gradle.kts'
+      - '.github/**'
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           path: "src"
 
       - name: Checkout builds
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           ref: "builds"
           path: "builds"
 
-      - name: Checkout Aliucord
-        uses: actions/checkout@master
-        with:
-          repository: "Aliucord/Aliucord"
-          path: "repo"
-
       - name: Setup JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
+          distribution: temurin
 
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
-      - name: Build Plugins
+      - name: Build plugins
         run: |
           cd $GITHUB_WORKSPACE/src
-          chmod +x gradlew
           ./gradlew make generateUpdaterJson
-          cp **/build/*.zip $GITHUB_WORKSPACE/builds
+          cp plugin/**/build/*.zip $GITHUB_WORKSPACE/builds
           cp build/updater.json $GITHUB_WORKSPACE/builds
 
       - name: Push builds
@@ -54,6 +47,6 @@ jobs:
           cd $GITHUB_WORKSPACE/builds
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
-          git add .
+          git add *
           git commit -m "Build $GITHUB_SHA" || exit 0   # do not error if nothing to commit
           git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: "Build"
 
+concurrency: 
+  group: "build"
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           cd $GITHUB_WORKSPACE/src
           chmod +x gradlew
           ./gradlew make generateUpdaterJson
-          cp plugin/**/build/*.zip $GITHUB_WORKSPACE/builds
+          cp **/build/*.zip $GITHUB_WORKSPACE/builds
           cp build/updater.json $GITHUB_WORKSPACE/builds
 
       - name: Push builds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           cd $GITHUB_WORKSPACE/src
           chmod +x gradlew
           ./gradlew make generateUpdaterJson
-          cp plugin/**/build/*.zip $GITHUB_WORKSPACE/builds
+          cp **/build/*.zip $GITHUB_WORKSPACE/builds
           cp build/updater.json $GITHUB_WORKSPACE/builds
 
       - name: Push builds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '*.md'
     paths:
       - 'gradle.properties'
       - 'gradle/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Build plugins
+      - name: Build Plugins
         run: |
           cd $GITHUB_WORKSPACE/src
           chmod +x gradlew
@@ -60,6 +60,6 @@ jobs:
           cd $GITHUB_WORKSPACE/builds
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
-          git add *
+          git add .
           git commit -m "Build $GITHUB_SHA" || exit 0   # do not error if nothing to commit
           git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           cd $GITHUB_WORKSPACE/src
           chmod +x gradlew
           ./gradlew make generateUpdaterJson
-          cp ./**/**/**/build/*.zip $GITHUB_WORKSPACE/builds
+          cp plugin/**/build/*.zip $GITHUB_WORKSPACE/builds
           cp build/updater.json $GITHUB_WORKSPACE/builds
 
       - name: Push builds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           cd $GITHUB_WORKSPACE/src
           chmod +x gradlew
           ./gradlew make generateUpdaterJson
-          cp **/build/*.zip $GITHUB_WORKSPACE/builds
+          cp ./**/**/**/build/*.zip $GITHUB_WORKSPACE/builds
           cp build/updater.json $GITHUB_WORKSPACE/builds
 
       - name: Push builds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '*.md'
     paths:
       - 'gradle.properties'
       - 'gradle/**'


### PR DESCRIPTION
this updates the build workflow to use ubuntu-latest instead of ubuntu-20.04, making it not queued for a very long time by github aswell as making it faster, this also makes some other small adjustments (almost all were from https://raw.githubusercontent.com/zt64/aliucord-plugins/refs/heads/main/.github/workflows/build.yml, which most plugin repositories use) 