### PR TITLE
fix: migrate from rawgithub to jsdelivr

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,8 +41,8 @@ subprojects {
     // Fill out with your info
     aliucord {
         author("DISCORD USERNAME", 123456789L)
-        updateUrl.set("https://raw.githubusercontent.com/USERNAME/REPONAME/builds/updater.json")
-        buildUrl.set("https://raw.githubusercontent.com/USERNAME/REPONAME/builds/%s.zip")
+        updateUrl.set("https://cdn.jsdelivr.net/gh/USERNAME/REPONAME@builds/updater.json")
+        buildUrl.set("https://cdn.jsdelivr.net/gh/USERNAME/REPONAME@builds/%s.zip")
     }
 
     android {


### PR DESCRIPTION
Migrates raw.githubusercontent.com urls to cdn.jsdelivr.net to solve all `429: Too Many Requests` errors on CGNAT networks after recent GitHub rate limit enforcements.